### PR TITLE
Fixed usage of int instead of int64

### DIFF
--- a/providers/telegram.go
+++ b/providers/telegram.go
@@ -87,7 +87,7 @@ func (p *providerTelegram) intakeLoop() {
 			for update := range upds {
 				senderID := strconv.Itoa(update.Message.From.ID)
 				senderName := update.Message.From.FirstName
-				targetID := strconv.Itoa(update.Message.Chat.ID)
+				targetID := strconv.FormatInt(update.Message.Chat.ID, 10)
 				targetName := update.Message.Chat.FirstName
 				msg := messages.Message{
 					Room:         "",
@@ -108,7 +108,7 @@ func (p *providerTelegram) intakeLoop() {
 func (p *providerTelegram) dispatchLoop() {
 	log.Println("telegram: started message dispatch loop")
 	for msg := range p.out {
-		id, err := strconv.Atoi(msg.ToUserID)
+		id, err := strconv.ParseInt(msg.ToUserID, 10, 64)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
This avoids the following errors which prevented building gochatbot with telegram provider enabled:

```
cirello.io/gochatbot/providers:
..\..\..\cirello.io\gochatbot\providers\telegram.go:90: cannot use
update.Message.Chat.ID (type int64) as type int in argument to strconv.Itoa
..\..\..\cirello.io\gochatbot\providers\telegram.go:122: cannot use id
(type int) as type int64 in argument to tgbotapi.NewMessage
```
